### PR TITLE
sanka#10: 'sets debug flag for CI "publish" workflow'

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,6 +48,7 @@ jobs:
           password: ${{ secrets.test_pypi_password }}
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
+          verbose: true
 
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
contributes to #10 